### PR TITLE
Performance improvements and additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The code is written in pure Matlab, and has no dependencies beyond Matlab itself. And it works in recent versions of Octave, too.
 The files in this repository are taken from [Transplant](https://github.com/bastibe/transplant).
-Parsemsgpack was adapted in order to improve performance and support also different ways of dealing with arrays and maps.
+Parsemsgpack was adapted in order to improve performance and support also different ways of dealing with arrays and maps (usage may also boot performace even more). See the code for more information.
 
 ## Basic Usage:
 ```matlab
@@ -41,7 +41,7 @@ There is no way of encoding exts
 | `true`/`false` | logical                   |
 | nil            | empty matrix              |
 | array          | cell array / (array)      |
-| map            | struct / (containers.Map) |
+| map            | containers.Map / (struct) |
 | bin            | uint8                     |
 | ext            | uint8                     |
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# A MessagePack implementation for Matlab and Octave
+# A performant MessagePack implementation for Matlab and Octave
 
 The code is written in pure Matlab, and has no dependencies beyond Matlab itself. And it works in recent versions of Octave, too.
-
 The files in this repository are taken from [Transplant](https://github.com/bastibe/transplant).
+Parsemsgpack was adapted in order to improve performance and support also different ways of dealing with arrays and maps.
 
 ## Basic Usage:
 ```matlab
@@ -34,18 +34,19 @@ There is no way of encoding exts
 
 ## Converting MsgPack to Matlab
 
-| MsgPack        | Matlab         |
-| -------------- | -------------- |
-| string         | string         |
-| number         | scalar         |
-| `true`/`false` | logical        |
-| nil            | empty matrix   |
-| array          | cell array     |
-| map            | containers.Map |
-| bin            | uint8          |
-| ext            | uint8          |
+| MsgPack        | Matlab                    |
+| -------------- | ------------------------- |
+| string         | string                    |
+| number         | scalar                    |
+| `true`/`false` | logical                   |
+| nil            | empty matrix              |
+| array          | cell array / (array)      |
+| map            | struct / (containers.Map) |
+| bin            | uint8                     |
+| ext            | uint8                     |
 
-Note that since `structs` don't support arbitrary field names, they can't be used for representing `maps`. We use `containers.Map` instead.
+Note that since `structs` don't support arbitrary field names, the fields will not always fully represent the serialized `maps`.
+Take a look at `parsemap` and `replaceMsgPackKey ` in `parsemsgpack` for more information.
 
 ## Tests
  ```matlab
@@ -57,6 +58,7 @@ Note that since `structs` don't support arbitrary field names, they can't be use
 MATLAB (R) is copyright of the Mathworks
 
 Copyright (c) 2014 Bastian Bechtold
+Voluntary contributions made by Christopher Nadler (cnadler86)
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/dumpmsgpack_test.m
+++ b/dumpmsgpack_test.m
@@ -88,7 +88,7 @@ data = struct();
 msgpack = uint8([]);
 for n=[1 10 11 12 13 14 15 16 2 3 4 5 6 7 8 9] % default struct field order
     data.(['x' num2str(n)]) = uint8(n);
-    msgpack = [msgpack dumpmsgpack(['x' num2str(n)]) uint8(n)];
+    msgpack = [msgpack dumpmsgpack(['x' num2str(n)]) uint8(n)]; %#ok<AGROW> 
 end
 if any(dumpmsgpack(data) ~= uint8([222, 0, 16, msgpack]))
     error('Dumping map16 failed')

--- a/parsemsgpack.m
+++ b/parsemsgpack.m
@@ -11,6 +11,7 @@
 %    - maps are converted to containers.Map
 
 % (c) 2016 Bastian Bechtold
+% voluntary contributions made by Christopher Nadler (cnadler86)
 % This code is licensed under the BSD 3-clause license
 
 function [obj, idx] = parsemsgpack(bytes)
@@ -19,24 +20,21 @@ end
 
 function [obj, idx] = parse(bytes, idx)
     % masks:
-    b10000000 = 128;
-    b01111111 = 127;
-    b11000000 = 192;
-    b00111111 = 63;
-    b11100000 = 224;
-    b00011111 = 31;
-    b11110000 = 240;
-    b00001111 = 15;
+    b10000000 = uint8(128);
+    b11100000 = uint8(224);
+    b00011111 = uint8(31);
+    b11110000 = uint8(240);
+    b00001111 = uint8(15);
     % values:
-    b00000000 = 0;
-    b10010000 = 144;
-    b10100000 = 160;
+    b00000000 = uint8(0);
+    b10010000 = uint8(144);
+    b10100000 = uint8(160);
 
     currentbyte = bytes(idx);
 
     if bitand(b10000000, currentbyte) == b00000000
         % decode positive fixint
-        obj = int8(currentbyte);
+        obj = int8(currentbyte);   %if you need more performance you could try to use uint8 instead of int here
         idx = idx + 1;
         return
     elseif bitand(b11100000, currentbyte) == b11100000
@@ -62,93 +60,93 @@ function [obj, idx] = parse(bytes, idx)
     end
 
     switch currentbyte
-        case 192 % nil
+        case uint8(192) % nil
             obj = [];
             idx = idx+1;
-      % case 193 % unused
-        case 194 % false
+      % case uint8(193 % unused
+        case uint8(194) % false
             obj = false;
             idx = idx+1;
-        case 195 % true
+        case uint8(195) % true
             obj = true;
             idx = idx+1;
-        case 196 % bin8
+        case uint8(196) % bin8
             len = double(bytes(idx+1));
             [obj, idx] = parsebytes(len, bytes, idx+2);
-        case 197 % bin16
+        case uint8(197) % bin16
             len = double(bytes2scalar(bytes(idx+1:idx+2), 'uint16'));
             [obj, idx] = parsebytes(len, bytes, idx+3);
-        case 198 % bin32
+        case uint8(198) % bin32
             len = double(bytes2scalar(bytes(idx+1:idx+4), 'uint32'));
             [obj, idx] = parsebytes(len, bytes, idx+5);
-        case 199 % ext8
+        case uint8(199) % ext8
             len = double(bytes(idx+1));
             [obj, idx] = parseext(len, bytes, idx+2);
-        case 200 % ext16
+        case uint8(200) % ext16
             len = double(bytes2scalar(bytes(idx+1:idx+2), 'uint16'));
             [obj, idx] = parseext(len, bytes, idx+3);
-        case 201 % ext32
+        case uint8(201) % ext32
             len = double(bytes2scalar(bytes(idx+1:idx+4), 'uint32'));
             [obj, idx] = parseext(len, bytes, idx+5);
-        case 202 % float32
+        case uint8(202) % float32
             obj = bytes2scalar(bytes(idx+1:idx+4), 'single');
             idx = idx+5;
-        case 203 % float64
+        case uint8(203) % float64
             obj = bytes2scalar(bytes(idx+1:idx+8), 'double');
             idx = idx+9;
-        case 204 % uint8
+        case uint8(204) % uint8
             obj = bytes(idx+1);
             idx = idx+2;
-        case 205 % uint16
+        case uint8(205) % uint16
             obj = bytes2scalar(bytes(idx+1:idx+2), 'uint16');
             idx = idx+3;
-        case 206 % uint32
+        case uint8(206) % uint32
             obj = bytes2scalar(bytes(idx+1:idx+4), 'uint32');
             idx = idx+5;
-        case 207 % uint64
+        case uint8(207) % uint64
             obj = bytes2scalar(bytes(idx+1:idx+8), 'uint64');
             idx = idx+9;
-        case 208 % int8
+        case uint8(208) % int8
             obj = bytes2scalar(bytes(idx+1), 'int8');
             idx = idx+2;
-        case 209 % int16
+        case uint8(209) % int16
             obj = bytes2scalar(bytes(idx+1:idx+2), 'int16');
             idx = idx+3;
-        case 210 % int32
+        case uint8(210) % int32
             obj = bytes2scalar(bytes(idx+1:idx+4), 'int32');
             idx = idx+5;
-        case 211 % int64
+        case uint8(211) % int64
             obj = bytes2scalar(bytes(idx+1:idx+8), 'int64');
             idx = idx+9;
-        case 212 % fixext1
+        case uint8(212) % fixext1
             [obj, idx] = parseext(1, bytes, idx+1);
-        case 213 % fixext2
+        case uint8(213) % fixext2
             [obj, idx] = parseext(2, bytes, idx+1);
-        case 214 % fixext4
+        case uint8(214) % fixext4
             [obj, idx] = parseext(4, bytes, idx+1);
-        case 215 % fixext8
+        case uint8(215) % fixext8
             [obj, idx] = parseext(8, bytes, idx+1);
-        case 216 % fixext16
+        case uint8(216) % fixext16
             [obj, idx] = parseext(16, bytes, idx+1);
-        case 217 % str8
+        case uint8(217) % str8
             len = double(bytes(idx+1));
             [obj, idx] = parsestring(len, bytes, idx+2);
-        case 218 % str16
+        case uint8(218) % str16
             len = double(bytes2scalar(bytes(idx+1:idx+2), 'uint16'));
             [obj, idx] = parsestring(len, bytes, idx+3);
-        case 219 % str32
+        case uint8(219) % str32
             len = double(bytes2scalar(bytes(idx+1:idx+4), 'uint32'));
             [obj, idx] = parsestring(len, bytes, idx+5);
-        case 220 % array16
+        case uint8(220) % array16
             len = double(bytes2scalar(bytes(idx+1:idx+2), 'uint16'));
             [obj, idx] = parsearray(len, bytes, idx+3);
-        case 221 % array32
+        case uint8(221) % array32
             len = double(bytes2scalar(bytes(idx+1:idx+4), 'uint32'));
             [obj, idx] = parsearray(len, bytes, idx+5);
-        case 222 % map16
+        case uint8(222) % map16
             len = double(bytes2scalar(bytes(idx+1:idx+2), 'uint16'));
             [obj, idx] = parsemap(len, bytes, idx+3);
-        case 223 % map32
+        case uint8(223) % map32
             len = double(bytes2scalar(bytes(idx+1:idx+4), 'uint32'));
             [obj, idx] = parsemap(len, bytes, idx+5);
         otherwise
@@ -179,16 +177,54 @@ function [out, idx] = parseext(len, bytes, idx)
 end
 
 function [out, idx] = parsearray(len, bytes, idx)
-    out = cell(1, len);
+    % out = cell(1, len);
+    % for n=1:len
+    %     [out{n}, idx] = parse(bytes, idx);
+    % end
+
+    % In most of the cases this is faster than using a preallocated cell (approach above). Array cannot be preallocated because the datatype is defined by the first call of the for loop.
+    % %Chosse how to manage arrays by commetinnig out/in.
     for n=1:len
-        [out{n}, idx] = parse(bytes, idx);
+        [out(n), idx] = parse(bytes, idx); %#ok<AGROW>: still better than using a cell and preallocating
     end
 end
 
 function [out, idx] = parsemap(len, bytes, idx)
-    out = containers.Map();
+    % out = containers.Map();
+    % for n=1:len
+    %     [key, idx] = parse(bytes, idx);
+    %     [out(key), idx] = parse(bytes, idx);
+    % end
+
+    %Using struct in faster and more user friendly. 
+    out = struct();
     for n=1:len
         [key, idx] = parse(bytes, idx);
-        [out(key), idx] = parse(bytes, idx);
+        [out.(replaceMsgPackKey(key)), idx] = parse(bytes, idx);
+    end
+end
+
+function ret = replaceMsgPackKey(num)
+    %add specific key names in here dependent on your specific msgpack serialisation.
+    %Always use uint8 in order to maintain performance.
+    % Example:
+        % switch num
+        %     case uint8(17)
+        %         ret = 'data';
+        %     case uint8(18)
+        %         ret = 'numOfElems';
+        %     case uint8(19)
+        %         ret = 'elemSz';
+        %     case uint8(20)
+        %         ret = 'endian';
+        %     case uint8(21)
+        %         ret = 'elemTypes';
+        %     case uint8(16)
+        %         ret = 'class';
+        % end
+
+    switch num
+        otherwise
+            ret = sprintf('Key%s',num);
     end
 end

--- a/parsemsgpack.m
+++ b/parsemsgpack.m
@@ -177,54 +177,16 @@ function [out, idx] = parseext(len, bytes, idx)
 end
 
 function [out, idx] = parsearray(len, bytes, idx)
-    % out = cell(1, len);
-    % for n=1:len
-    %     [out{n}, idx] = parse(bytes, idx);
-    % end
-
-    % In most of the cases this is faster than using a preallocated cell (approach above). Array cannot be preallocated because the datatype is defined by the first call of the for loop.
-    % %Chosse how to manage arrays by commetinnig out/in.
+    out = cell(1, len);
     for n=1:len
-        [out(n), idx] = parse(bytes, idx); %#ok<AGROW>: still better than using a cell and preallocating
+        [out{n}, idx] = parse(bytes, idx);
     end
 end
 
 function [out, idx] = parsemap(len, bytes, idx)
-    % out = containers.Map();
-    % for n=1:len
-    %     [key, idx] = parse(bytes, idx);
-    %     [out(key), idx] = parse(bytes, idx);
-    % end
-
-    %Using struct in faster and more user friendly. 
-    out = struct();
+    out = containers.Map();
     for n=1:len
         [key, idx] = parse(bytes, idx);
-        [out.(replaceMsgPackKey(key)), idx] = parse(bytes, idx);
-    end
-end
-
-function ret = replaceMsgPackKey(num)
-    %add specific key names in here dependent on your specific msgpack serialisation.
-    %Always use uint8 in order to maintain performance.
-    % Example:
-        % switch num
-        %     case uint8(17)
-        %         ret = 'data';
-        %     case uint8(18)
-        %         ret = 'numOfElems';
-        %     case uint8(19)
-        %         ret = 'elemSz';
-        %     case uint8(20)
-        %         ret = 'endian';
-        %     case uint8(21)
-        %         ret = 'elemTypes';
-        %     case uint8(16)
-        %         ret = 'class';
-        % end
-
-    switch num
-        otherwise
-            ret = sprintf('Key%s',num);
+        [out(key), idx] = parse(bytes, idx);
     end
 end

--- a/parsemsgpack.m
+++ b/parsemsgpack.m
@@ -196,7 +196,7 @@ function [out, idx] = parsemap(len, bytes, idx)
 %     out = containers.Map();
 %     for n=1:len
 %         [key, idx] = parse(bytes, idx);
-%         [out(key), idx] = parse(bytes, idx);
+%         [out(string(key)), idx] = parse(bytes, idx);
 %     end
 
     % In most of the cases using struct is faster and more user friendly.
@@ -210,7 +210,7 @@ function [out, idx] = parsemap(len, bytes, idx)
 end
 
 function ret = replaceMsgPackKey(num)
-    % If needed dependent on your specific msgpack serialisation, add specific mapping for key-names in here.
+    % If needed, dependent on your specific msgpack serialisation, add specific mapping for key-names in here.
     % In this case use int8 / uint8 in the case statements in order to maintain performance (depending on the data type of num).
     % Example:
         % switch num
@@ -222,11 +222,17 @@ function ret = replaceMsgPackKey(num)
         %         ret = 'class';
         % end
     if ischar(num) || isstring(num)
-        ret=matlab.lang.makeValidName(num);     %used in order to support most of the possible arbitrary field names.
-    else
+        if isvarname(num)
+            ret=num;
+        else
+            ret=matlab.lang.makeValidName(num);     %used in order to support most of the possible arbitrary field names.
+        end
+    elseif isnumeric(num)
         switch num
             otherwise
-                ret = sprintf('Key%s',num);
+                ret = strrep(sprintf('Key%d',num),'-','_');
         end
+    else
+        ret=matlab.lang.makeValidName(string(num));
     end
 end

--- a/parsemsgpack_test.m
+++ b/parsemsgpack_test.m
@@ -133,7 +133,7 @@ data = struct();
 msgpack = uint8([222, 0, 16]);
 for n=[1 10 11 12 13 14 15 16 2 3 4 5 6 7 8 9] % default struct field order
     data.(['x' num2str(n)]) = uint8(n);
-    msgpack = [msgpack dumpmsgpack(['x' num2str(n)]) uint8(n)];
+    msgpack = [msgpack dumpmsgpack(['x' num2str(n)]) uint8(n)]; %#ok<AGROW> 
 end
 c = parsemsgpack(msgpack);
 d = data;


### PR DESCRIPTION
Hi,
I profiled the parser and improved the performance by reducing the typecasts that matlab runs in the background. In my opinion the parser is now run-time capable (depending on the amount of data).

Also added the possibility to return normal arrays instead of cells (the user needs to comment it out/in) and I used struct instead of containers.map as default (see implementation in order to deal with "bad names").